### PR TITLE
Fix Yarn Command Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install melon-fire
 or
 
 ```
-yarn install melon-fire
+yarn add melon-fire
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ async function onSyncButtonPushOrRandomTimer(
   userId: string,
 ) {
   const syncDocRef = firestore()
-    .collections("users")
+    .collection("users")
     .doc(userId);
   return await syncMelonFire(db, syncDocRef);
 }


### PR DESCRIPTION
There was a small typo in the readme.md for the yarn install command. 
It should be `yarn add yarn add melon-fire` instead of `yarn install melon-fire`

EDIT: I found another typo (`collection` instead of `collections`) so I just decided to add it to this PR